### PR TITLE
[ivy][persp] Use `d` instead of `C-d` to open dired

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -243,4 +243,4 @@
     :init (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)
     :config (ivy-set-actions
              'spacemacs/ivy-persp-switch-project
-             '(("" spacemacs/ivy-switch-project-open-dired "dired")))))
+             '(("d" spacemacs/ivy-switch-project-open-dired "dired")))))


### PR DESCRIPTION
The argument here https://github.com/syl20bnr/spacemacs/pull/13175#issuecomment-575990985 makes more sense to stick with `ivy` conventions.